### PR TITLE
Add product search pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,16 @@ curl -X POST http://localhost:8080/products \
 curl http://localhost:8080/products/by-category/Electronics
 ```
 
-#### `GET /products/search?name=&minPrice=&maxPrice=`
+#### `GET /products/search?name=&minPrice=&maxPrice=&page=&size=`
+
+Pagination:
+- `page` is **one-based** (`page=1` is the first page)
+- defaults: `page=1`, `size=20`
+- `size` must be between `1` and `100`
+- default sort is `id,asc`
 
 ```bash
-curl "http://localhost:8080/products/search?name=laptop&minPrice=1000&maxPrice=2000"
+curl "http://localhost:8080/products/search?name=laptop&minPrice=1000&maxPrice=2000&page=1&size=20"
 ```
 
 #### `GET /products/summaries`

--- a/README.md
+++ b/README.md
@@ -309,8 +309,3 @@ src/
     Products.http
     Order.http
 ```
-
-## Current Limitations
-
-- No pagination on product listing/search endpoints.
-- Error payload is intentionally minimal (`{ "error": "..." }`).

--- a/src/httpreq/Products.http
+++ b/src/httpreq/Products.http
@@ -36,7 +36,7 @@ DELETE http://localhost:8080/products/1
 GET http://localhost:8080/products/by-category/Electronics
 
 ###
-GET http://localhost:8080/products/search?name=prod&minPrice=10&maxPrice=100
+GET http://localhost:8080/products/search?name=prod&minPrice=10&maxPrice=100&page=1&size=20
 
 ###
 GET http://localhost:8080/products/summaries

--- a/src/main/java/com/interview/demo/controller/ProductController.java
+++ b/src/main/java/com/interview/demo/controller/ProductController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,11 +41,13 @@ public class ProductController {
   }
 
   @GetMapping("/search")
-  public List<ProductResponse> searchProducts(
+  public Page<ProductResponse> searchProducts(
       @RequestParam(required = false) String name,
       @RequestParam(required = false) BigDecimal minPrice,
-      @RequestParam(required = false) BigDecimal maxPrice) {
-    return productService.searchProducts(name, minPrice, maxPrice);
+      @RequestParam(required = false) BigDecimal maxPrice,
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "20") int size) {
+    return productService.searchProducts(name, minPrice, maxPrice, page, size);
   }
 
   @GetMapping("/summaries")

--- a/src/main/java/com/interview/demo/service/ProductService.java
+++ b/src/main/java/com/interview/demo/service/ProductService.java
@@ -14,6 +14,10 @@ import com.interview.demo.repository.specification.ProductSpecifications;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -60,13 +64,21 @@ public class ProductService {
   }
 
   @Transactional(readOnly = true)
-  public List<ProductResponse> searchProducts(
-      String name, BigDecimal minPrice, BigDecimal maxPrice) {
+  public Page<ProductResponse> searchProducts(
+      String name, BigDecimal minPrice, BigDecimal maxPrice, int page, int size) {
+    if (page < 1) {
+      throw new ValidationException("page must be at least 1");
+    }
+    if (size < 1 || size > 100) {
+      throw new ValidationException("size must be between 1 and 100");
+    }
+
     Specification<Product> spec =
         ProductSpecifications.nameContains(name)
             .and(ProductSpecifications.priceGte(minPrice))
             .and(ProductSpecifications.priceLte(maxPrice));
-    return productRepository.findAll(spec).stream().map(this::toResponse).toList();
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.ASC, "id"));
+    return productRepository.findAll(spec, pageable).map(this::toResponse);
   }
 
   public List<ProductSummary> getProductSummaries() {

--- a/src/test/java/com/interview/demo/InventoryApiIT.java
+++ b/src/test/java/com/interview/demo/InventoryApiIT.java
@@ -123,8 +123,60 @@ class InventoryApiIT extends PostgresContainerTestBase {
                 .param("minPrice", "1000")
                 .param("maxPrice", "1700"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(1))
-        .andExpect(jsonPath("$[0].name").value("Gaming Laptop"));
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].name").value("Gaming Laptop"))
+        .andExpect(jsonPath("$.number").value(0))
+        .andExpect(jsonPath("$.size").value(20))
+        .andExpect(jsonPath("$.totalElements").value(1));
+  }
+
+  @Test
+  void shouldUseDefaultPaginationWhenSearchingProducts() throws Exception {
+    for (int i = 1; i <= 25; i++) {
+      productRepository.save(product("Laptop " + i, new BigDecimal("1000.00")));
+    }
+
+    mockMvc
+        .perform(get("/products/search").param("name", "laptop"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content.length()").value(20))
+        .andExpect(jsonPath("$.number").value(0))
+        .andExpect(jsonPath("$.size").value(20))
+        .andExpect(jsonPath("$.totalElements").value(25))
+        .andExpect(jsonPath("$.totalPages").value(2));
+  }
+
+  @Test
+  void shouldReturnSecondPageWhenUsingOneBasedPageParameter() throws Exception {
+    productRepository.save(product("Laptop 1", new BigDecimal("1000.00")));
+    productRepository.save(product("Laptop 2", new BigDecimal("1000.00")));
+    productRepository.save(product("Laptop 3", new BigDecimal("1000.00")));
+
+    mockMvc
+        .perform(get("/products/search").param("name", "laptop").param("page", "2").param("size", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].name").value("Laptop 3"))
+        .andExpect(jsonPath("$.number").value(1))
+        .andExpect(jsonPath("$.size").value(2))
+        .andExpect(jsonPath("$.totalElements").value(3))
+        .andExpect(jsonPath("$.totalPages").value(2));
+  }
+
+  @Test
+  void shouldReturnBadRequestForInvalidSearchPage() throws Exception {
+    mockMvc
+        .perform(get("/products/search").param("page", "0"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("page must be at least 1"));
+  }
+
+  @Test
+  void shouldReturnBadRequestForInvalidSearchSize() throws Exception {
+    mockMvc
+        .perform(get("/products/search").param("size", "101"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("size must be between 1 and 100"));
   }
 
   @Test


### PR DESCRIPTION
• Implemented pagination for searchProducts with the planned contract.

  Changes made:

  - Updated endpoint to accept page and size and return paged JSON (Page<ProductResponse>): src/main/java/com/interview/demo/controller/
    ProductController.java:43
  - Added one-based pagination handling, defaults, validation, and stable sorting:
      - page >= 1
      - size between 1 and 100
      - default sort id,asc
      - one-based request converted to zero-based PageRequest
      - src/main/java/com/interview/demo/service/ProductService.java:67
  - Updated integration coverage for:
      - paged response shape
      - default pagination (page=1, size=20)
      - one-based page behavior
      - invalid page/size returning 400
      - src/test/java/com/interview/demo/InventoryApiIT.java:113
  - Updated docs/examples:
      - README.md:127
      - src/httpreq/Products.http:39