### PR TITLE
Implement hateoas

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Spring Boot REST API for categories, products, and orders, backed by PostgreSQL,
 - Spring Web
 - Spring Data JPA
 - Spring Validation (`jakarta.validation`)
+- Spring HATEOAS
 - Flyway (schema migrations)
 - PostgreSQL
 - Testcontainers (integration tests)
@@ -29,6 +30,15 @@ Main domain entities:
 - `Product`
 - `Order`
 - `OrderItem`
+
+## Hypermedia Responses
+
+The API now uses Spring HATEOAS and returns HAL-style JSON for resource responses.
+
+- Single-resource responses include `_links` such as `self`.
+- Collection responses include `_embedded` plus collection-level `_links`.
+- Product search returns a paged HAL response with page metadata under `page`.
+- Validation and error responses remain plain JSON objects such as `{ "error": "..." }`.
 
 ## Getting Started
 
@@ -73,6 +83,41 @@ API base URL: `http://localhost:8080`
 curl http://localhost:8080/categories
 ```
 
+Example response:
+
+```json
+{
+  "_embedded": {
+    "categoryResponseList": [
+      {
+        "id": 1,
+        "name": "Electronics",
+        "_links": {
+          "self": { "href": "http://localhost:8080/categories/1" },
+          "categories": { "href": "http://localhost:8080/categories" },
+          "products": { "href": "http://localhost:8080/products/by-category/Electronics" }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": { "href": "http://localhost:8080/categories" }
+  }
+}
+```
+
+#### `GET /categories/{id}`
+
+```bash
+curl http://localhost:8080/categories/1
+```
+
+#### `GET /categories/details`
+
+```bash
+curl "http://localhost:8080/categories/details?page=1&size=20"
+```
+
 #### `POST /categories`
 
 ```bash
@@ -101,6 +146,12 @@ curl -X DELETE http://localhost:8080/categories/1
 
 ```bash
 curl http://localhost:8080/products
+```
+
+#### `GET /products/{id}`
+
+```bash
+curl http://localhost:8080/products/1
 ```
 
 #### `POST /products`
@@ -136,10 +187,65 @@ Pagination:
 curl "http://localhost:8080/products/search?name=laptop&minPrice=1000&maxPrice=2000&page=1&size=20"
 ```
 
+Example response:
+
+```json
+{
+  "_embedded": {
+    "productResponseList": [
+      {
+        "id": 1,
+        "name": "Gaming Laptop",
+        "description": "High-end laptop",
+        "price": 1500.00,
+        "categoryId": 1,
+        "categoryName": "Electronics",
+        "_links": {
+          "self": { "href": "http://localhost:8080/products/1" },
+          "products": { "href": "http://localhost:8080/products" },
+          "category": { "href": "http://localhost:8080/categories/1" }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "http://localhost:8080/products/search?name=laptop&minPrice=1000&maxPrice=2000&page=1&size=20"
+    }
+  },
+  "page": {
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "number": 0
+  }
+}
+```
+
 #### `GET /products/summaries`
 
 ```bash
 curl http://localhost:8080/products/summaries
+```
+
+This endpoint returns concrete summary resources in HAL under `_embedded.productSummaryResponseList`.
+
+Example response:
+
+```json
+{
+  "_embedded": {
+    "productSummaryResponseList": [
+      {
+        "name": "Monitor",
+        "price": 299.99
+      }
+    ]
+  },
+  "_links": {
+    "self": { "href": "http://localhost:8080/products/summaries" }
+  }
+}
 ```
 
 #### `PUT /products/{id}`
@@ -182,6 +288,18 @@ curl -X DELETE http://localhost:8080/products/1
 
 ### Orders
 
+#### `GET /orders`
+
+```bash
+curl http://localhost:8080/orders
+```
+
+#### `GET /orders/{id}`
+
+```bash
+curl http://localhost:8080/orders/1
+```
+
 #### `POST /orders`
 
 ```bash
@@ -203,6 +321,37 @@ Returns order items for the given order id, including `productName`.
 ```bash
 curl http://localhost:8080/orders/1/items
 ```
+
+Example order response:
+
+```json
+{
+  "id": 1,
+  "customerName": "Alice",
+  "status": "CREATED",
+  "totalAmount": 250.00,
+  "createdAt": "2026-04-26",
+  "items": [
+    {
+      "id": 1,
+      "productId": 1,
+      "productName": "Keyboard",
+      "quantity": 2,
+      "unitPrice": 100.00,
+      "lineTotal": 200.00
+    }
+  ],
+  "_links": {
+    "self": { "href": "http://localhost:8080/orders/1" },
+    "orders": { "href": "http://localhost:8080/orders" },
+    "items": { "href": "http://localhost:8080/orders/1/items" },
+    "confirm": { "href": "http://localhost:8080/orders/1" },
+    "cancel": { "href": "http://localhost:8080/orders/1" }
+  }
+}
+```
+
+For orders with status `CONFIRMED` or `CANCELLED`, the transition links `confirm` and `cancel` are omitted.
 
 #### `PUT /orders/{id}`
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/interview/demo/controller/CategoryController.java
+++ b/src/main/java/com/interview/demo/controller/CategoryController.java
@@ -3,10 +3,14 @@ package com.interview.demo.controller;
 import com.interview.demo.dto.CategoryResponse;
 import com.interview.demo.dto.CategoryResponseDetails;
 import com.interview.demo.dto.CreateCategoryRequest;
+import com.interview.demo.hateoas.CategoryModelAssembler;
 import com.interview.demo.service.CategoryServiceContract;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,31 +25,53 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/categories")
 public class CategoryController {
   private final CategoryServiceContract categoryService;
+  private final CategoryModelAssembler categoryAssembler;
 
-  public CategoryController(CategoryServiceContract categoryService) {
+  public CategoryController(
+      CategoryServiceContract categoryService, CategoryModelAssembler categoryAssembler) {
     this.categoryService = categoryService;
+    this.categoryAssembler = categoryAssembler;
   }
 
   @GetMapping
-  public List<CategoryResponse> getAllCategories() {
-    return categoryService.getAllCategories();
+  public CollectionModel<EntityModel<CategoryResponse>> getAllCategories() {
+    List<EntityModel<CategoryResponse>> categories =
+        categoryService.getAllCategories().stream().map(categoryAssembler::toModel).toList();
+    return CollectionModel.of(
+        categories,
+        WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(CategoryController.class).getAllCategories())
+            .withSelfRel());
+  }
+
+  @GetMapping("/{id}")
+  public EntityModel<CategoryResponse> getCategoryById(@PathVariable Long id) {
+    return categoryAssembler.toModel(categoryService.getCategoryById(id));
   }
 
   @GetMapping("/details")
-  public List<CategoryResponseDetails> getAllCategoriesDetails(
+  public CollectionModel<EntityModel<CategoryResponseDetails>> getAllCategoriesDetails(
       @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "20") int size) {
-    return categoryService.getAllCategoriesDetails(page, size);
+    List<EntityModel<CategoryResponseDetails>> categories =
+        categoryService.getAllCategoriesDetails(page, size).stream()
+            .map(categoryAssembler::toDetailsModel)
+            .toList();
+    return CollectionModel.of(
+        categories,
+        WebMvcLinkBuilder.linkTo(
+                WebMvcLinkBuilder.methodOn(CategoryController.class)
+                    .getAllCategoriesDetails(page, size))
+            .withSelfRel());
   }
 
   @PostMapping
-  public CategoryResponse createCategory(@Valid @RequestBody CreateCategoryRequest request) {
-    return categoryService.createCategory(request);
+  public EntityModel<CategoryResponse> createCategory(@Valid @RequestBody CreateCategoryRequest request) {
+    return categoryAssembler.toModel(categoryService.createCategory(request));
   }
 
   @PutMapping("/{id}")
-  public CategoryResponse updateCategory(
+  public EntityModel<CategoryResponse> updateCategory(
       @PathVariable Long id, @Valid @RequestBody CreateCategoryRequest request) {
-    return categoryService.updateCategory(id, request);
+    return categoryAssembler.toModel(categoryService.updateCategory(id, request));
   }
 
   @DeleteMapping("/{id}")

--- a/src/main/java/com/interview/demo/controller/OrderController.java
+++ b/src/main/java/com/interview/demo/controller/OrderController.java
@@ -4,10 +4,14 @@ import com.interview.demo.dto.order.CreateOrderRequest;
 import com.interview.demo.dto.order.OrderItemResponse;
 import com.interview.demo.dto.order.OrderResponse;
 import com.interview.demo.dto.order.UpdateOrderStatusRequest;
+import com.interview.demo.hateoas.OrderModelAssembler;
 import com.interview.demo.service.OrderServiceContract;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,25 +25,50 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/orders")
 public class OrderController {
   private final OrderServiceContract orderService;
+  private final OrderModelAssembler orderAssembler;
 
-  public OrderController(OrderServiceContract orderService) {
+  public OrderController(OrderServiceContract orderService, OrderModelAssembler orderAssembler) {
     this.orderService = orderService;
+    this.orderAssembler = orderAssembler;
+  }
+
+  @GetMapping
+  public CollectionModel<EntityModel<OrderResponse>> getAllOrders() {
+    List<EntityModel<OrderResponse>> orders =
+        orderService.getAllOrders().stream().map(orderAssembler::toModel).toList();
+    return CollectionModel.of(
+        orders,
+        WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(OrderController.class).getAllOrders())
+            .withSelfRel());
+  }
+
+  @GetMapping("/{id}")
+  public EntityModel<OrderResponse> getOrderById(@PathVariable Long id) {
+    return orderAssembler.toModel(orderService.getOrderById(id));
   }
 
   @PostMapping
-  public OrderResponse createOrder(@Valid @RequestBody CreateOrderRequest request) {
-    return orderService.createOrder(request);
+  public EntityModel<OrderResponse> createOrder(@Valid @RequestBody CreateOrderRequest request) {
+    return orderAssembler.toModel(orderService.createOrder(request));
   }
 
   @GetMapping("/{id}/items")
-  public List<OrderItemResponse> getOrderItemsByOrderId(@PathVariable Long id) {
-    return orderService.getOrderItemsByOrderId(id);
+  public CollectionModel<EntityModel<OrderItemResponse>> getOrderItemsByOrderId(@PathVariable Long id) {
+    List<EntityModel<OrderItemResponse>> items =
+        orderService.getOrderItemsByOrderId(id).stream()
+            .map(item -> orderAssembler.toItemModel(id, item))
+            .toList();
+    return CollectionModel.of(
+        items,
+        WebMvcLinkBuilder.linkTo(
+                WebMvcLinkBuilder.methodOn(OrderController.class).getOrderItemsByOrderId(id))
+            .withSelfRel());
   }
 
   @PutMapping("/{id}")
-  public OrderResponse updateOrderStatus(
+  public EntityModel<OrderResponse> updateOrderStatus(
       @PathVariable Long id, @Valid @RequestBody UpdateOrderStatusRequest request) {
-    return orderService.updateOrderStatus(id, request);
+    return orderAssembler.toModel(orderService.updateOrderStatus(id, request));
   }
 
   @DeleteMapping("/{id}")

--- a/src/main/java/com/interview/demo/controller/ProductController.java
+++ b/src/main/java/com/interview/demo/controller/ProductController.java
@@ -2,14 +2,20 @@ package com.interview.demo.controller;
 
 import com.interview.demo.dto.ProductDTO;
 import com.interview.demo.dto.ProductResponse;
+import com.interview.demo.dto.ProductSummaryResponse;
 import com.interview.demo.dto.PatchProductRequest;
-import com.interview.demo.repository.projection.ProductSummary;
+import com.interview.demo.hateoas.ProductModelAssembler;
 import com.interview.demo.service.ProductServiceContract;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import org.springframework.data.domain.Page;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
+import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,49 +31,78 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/products")
 public class ProductController {
   private final ProductServiceContract productService;
+  private final ProductModelAssembler productAssembler;
 
-  public ProductController(ProductServiceContract productService) {
+  public ProductController(
+      ProductServiceContract productService, ProductModelAssembler productAssembler) {
     this.productService = productService;
+    this.productAssembler = productAssembler;
   }
 
   @GetMapping
-  public List<ProductResponse> getAllProducts() {
-    return productService.getAllProducts();
+  public CollectionModel<EntityModel<ProductResponse>> getAllProducts() {
+    List<EntityModel<ProductResponse>> products =
+        productService.getAllProducts().stream().map(productAssembler::toModel).toList();
+    return CollectionModel.of(
+        products,
+        WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ProductController.class).getAllProducts())
+            .withSelfRel());
+  }
+
+  @GetMapping("/{id}")
+  public EntityModel<ProductResponse> getProductById(@PathVariable Long id) {
+    return productAssembler.toModel(productService.getProductById(id));
   }
 
   @GetMapping("/by-category/{categoryName}")
-  public List<ProductResponse> findByCategoryName(@PathVariable String categoryName) {
-    return productService.findByCategoryName(categoryName);
+  public CollectionModel<EntityModel<ProductResponse>> findByCategoryName(
+      @PathVariable String categoryName) {
+    List<EntityModel<ProductResponse>> products =
+        productService.findByCategoryName(categoryName).stream()
+            .map(productAssembler::toModel)
+            .toList();
+    return CollectionModel.of(
+        products,
+        WebMvcLinkBuilder.linkTo(
+                WebMvcLinkBuilder.methodOn(ProductController.class).findByCategoryName(categoryName))
+            .withSelfRel());
   }
 
   @GetMapping("/search")
-  public Page<ProductResponse> searchProducts(
+  public PagedModel<EntityModel<ProductResponse>> searchProducts(
       @RequestParam(required = false) String name,
       @RequestParam(required = false) BigDecimal minPrice,
       @RequestParam(required = false) BigDecimal maxPrice,
       @RequestParam(defaultValue = "1") int page,
-      @RequestParam(defaultValue = "20") int size) {
-    return productService.searchProducts(name, minPrice, maxPrice, page, size);
+      @RequestParam(defaultValue = "20") int size,
+      PagedResourcesAssembler<ProductResponse> pagedResourcesAssembler) {
+    Page<ProductResponse> result = productService.searchProducts(name, minPrice, maxPrice, page, size);
+    return pagedResourcesAssembler.toModel(result, productAssembler);
   }
 
   @GetMapping("/summaries")
-  public List<ProductSummary> getProductSummaries() {
-    return productService.getProductSummaries();
+  public CollectionModel<ProductSummaryResponse> getProductSummaries() {
+    return CollectionModel.of(
+        productService.getProductSummaries(),
+        WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ProductController.class).getProductSummaries())
+            .withSelfRel());
   }
 
   @PostMapping
-  public ProductResponse createProduct(@Valid @RequestBody ProductDTO product) {
-    return productService.saveProduct(product);
+  public EntityModel<ProductResponse> createProduct(@Valid @RequestBody ProductDTO product) {
+    return productAssembler.toModel(productService.saveProduct(product));
   }
 
   @PutMapping("/{id}")
-  public ProductResponse updateProduct(@PathVariable Long id, @Valid @RequestBody ProductDTO product) {
-    return productService.updateProduct(id, product);
+  public EntityModel<ProductResponse> updateProduct(
+      @PathVariable Long id, @Valid @RequestBody ProductDTO product) {
+    return productAssembler.toModel(productService.updateProduct(id, product));
   }
 
   @PatchMapping("/{id}")
-  public ProductResponse patchProduct(@PathVariable Long id, @RequestBody PatchProductRequest request) {
-    return productService.patchProduct(id, request);
+  public EntityModel<ProductResponse> patchProduct(
+      @PathVariable Long id, @RequestBody PatchProductRequest request) {
+    return productAssembler.toModel(productService.patchProduct(id, request));
   }
 
   @DeleteMapping("/{id}")

--- a/src/main/java/com/interview/demo/dto/ProductSummaryResponse.java
+++ b/src/main/java/com/interview/demo/dto/ProductSummaryResponse.java
@@ -1,0 +1,5 @@
+package com.interview.demo.dto;
+
+import java.math.BigDecimal;
+
+public record ProductSummaryResponse(String name, BigDecimal price) {}

--- a/src/main/java/com/interview/demo/hateoas/CategoryModelAssembler.java
+++ b/src/main/java/com/interview/demo/hateoas/CategoryModelAssembler.java
@@ -1,0 +1,36 @@
+package com.interview.demo.hateoas;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+import com.interview.demo.controller.CategoryController;
+import com.interview.demo.controller.ProductController;
+import com.interview.demo.dto.CategoryResponse;
+import com.interview.demo.dto.CategoryResponseDetails;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryModelAssembler
+    implements RepresentationModelAssembler<CategoryResponse, EntityModel<CategoryResponse>> {
+
+  @Override
+  public EntityModel<CategoryResponse> toModel(CategoryResponse category) {
+    return EntityModel.of(
+        category,
+        linkTo(methodOn(CategoryController.class).getCategoryById(category.id())).withSelfRel(),
+        linkTo(methodOn(CategoryController.class).getAllCategories()).withRel("categories"),
+        linkTo(methodOn(ProductController.class).findByCategoryName(category.name()))
+            .withRel("products"));
+  }
+
+  public EntityModel<CategoryResponseDetails> toDetailsModel(CategoryResponseDetails category) {
+    return EntityModel.of(
+        category,
+        linkTo(methodOn(CategoryController.class).getCategoryById(category.id())).withSelfRel(),
+        linkTo(methodOn(CategoryController.class).getAllCategories()).withRel("categories"),
+        linkTo(methodOn(ProductController.class).findByCategoryName(category.name()))
+            .withRel("products"));
+  }
+}

--- a/src/main/java/com/interview/demo/hateoas/OrderModelAssembler.java
+++ b/src/main/java/com/interview/demo/hateoas/OrderModelAssembler.java
@@ -1,0 +1,54 @@
+package com.interview.demo.hateoas;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+import com.interview.demo.controller.OrderController;
+import com.interview.demo.controller.ProductController;
+import com.interview.demo.dto.order.OrderItemResponse;
+import com.interview.demo.dto.order.OrderResponse;
+import com.interview.demo.dto.order.UpdateOrderStatusRequest;
+import com.interview.demo.entity.OrderStatus;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderModelAssembler
+    implements RepresentationModelAssembler<OrderResponse, EntityModel<OrderResponse>> {
+
+  @Override
+  public EntityModel<OrderResponse> toModel(OrderResponse order) {
+    EntityModel<OrderResponse> model =
+        EntityModel.of(
+            order,
+            linkTo(methodOn(OrderController.class).getOrderById(order.id())).withSelfRel(),
+            linkTo(methodOn(OrderController.class).getAllOrders()).withRel("orders"),
+            linkTo(methodOn(OrderController.class).getOrderItemsByOrderId(order.id()))
+                .withRel("items"));
+
+    if (order.status() == OrderStatus.CREATED) {
+      model.add(
+          linkTo(
+                  methodOn(OrderController.class)
+                      .updateOrderStatus(
+                          order.id(), new UpdateOrderStatusRequest(OrderStatus.CONFIRMED)))
+              .withRel("confirm"));
+      model.add(
+          linkTo(
+                  methodOn(OrderController.class)
+                      .updateOrderStatus(
+                          order.id(), new UpdateOrderStatusRequest(OrderStatus.CANCELLED)))
+              .withRel("cancel"));
+    }
+
+    return model;
+  }
+
+  public EntityModel<OrderItemResponse> toItemModel(Long orderId, OrderItemResponse item) {
+    return EntityModel.of(
+        item,
+        linkTo(methodOn(ProductController.class).getProductById(item.productId())).withRel("product"),
+        linkTo(methodOn(OrderController.class).getOrderById(orderId)).withRel("order"));
+  }
+}

--- a/src/main/java/com/interview/demo/hateoas/ProductModelAssembler.java
+++ b/src/main/java/com/interview/demo/hateoas/ProductModelAssembler.java
@@ -1,0 +1,33 @@
+package com.interview.demo.hateoas;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+import com.interview.demo.controller.CategoryController;
+import com.interview.demo.controller.ProductController;
+import com.interview.demo.dto.ProductResponse;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductModelAssembler
+    implements RepresentationModelAssembler<ProductResponse, EntityModel<ProductResponse>> {
+
+  @Override
+  public EntityModel<ProductResponse> toModel(ProductResponse product) {
+    EntityModel<ProductResponse> model =
+        EntityModel.of(
+            product,
+            linkTo(methodOn(ProductController.class).getProductById(product.id())).withSelfRel(),
+            linkTo(methodOn(ProductController.class).getAllProducts()).withRel("products"));
+
+    if (product.categoryId() != null) {
+      model.add(
+          linkTo(methodOn(CategoryController.class).getCategoryById(product.categoryId()))
+              .withRel("category"));
+    }
+
+    return model;
+  }
+}

--- a/src/main/java/com/interview/demo/service/CategoryService.java
+++ b/src/main/java/com/interview/demo/service/CategoryService.java
@@ -46,6 +46,11 @@ public class CategoryService implements CategoryServiceContract {
   }
 
   @Transactional(readOnly = true)
+  public CategoryResponse getCategoryById(Long id) {
+    return toResponse(getById(id));
+  }
+
+  @Transactional(readOnly = true)
   public List<CategoryResponseDetails> getAllCategoriesDetails(int page, int size) {
     if (page < 1) {
       throw new ValidationException("page must be at least 1");

--- a/src/main/java/com/interview/demo/service/CategoryServiceContract.java
+++ b/src/main/java/com/interview/demo/service/CategoryServiceContract.java
@@ -11,6 +11,8 @@ public interface CategoryServiceContract {
 
   List<CategoryResponse> getAllCategories();
 
+  CategoryResponse getCategoryById(Long id);
+
   List<CategoryResponseDetails> getAllCategoriesDetails(int page, int size);
 
   CategoryResponse updateCategory(Long id, CreateCategoryRequest request);

--- a/src/main/java/com/interview/demo/service/OrderService.java
+++ b/src/main/java/com/interview/demo/service/OrderService.java
@@ -28,6 +28,16 @@ public class OrderService implements OrderServiceContract {
     this.productService = productService;
   }
 
+  @Transactional(readOnly = true)
+  public List<OrderResponse> getAllOrders() {
+    return orderRepository.findAll().stream().map(this::toResponse).toList();
+  }
+
+  @Transactional(readOnly = true)
+  public OrderResponse getOrderById(Long orderId) {
+    return toResponse(getById(orderId));
+  }
+
   @Transactional
   public OrderResponse createOrder(CreateOrderRequest request) {
     if (request.items() == null || request.items().isEmpty()) {

--- a/src/main/java/com/interview/demo/service/OrderServiceContract.java
+++ b/src/main/java/com/interview/demo/service/OrderServiceContract.java
@@ -7,6 +7,10 @@ import com.interview.demo.dto.order.UpdateOrderStatusRequest;
 import java.util.List;
 
 public interface OrderServiceContract {
+  List<OrderResponse> getAllOrders();
+
+  OrderResponse getOrderById(Long orderId);
+
   OrderResponse createOrder(CreateOrderRequest request);
 
   List<OrderItemResponse> getOrderItemsByOrderId(Long orderId);

--- a/src/main/java/com/interview/demo/service/ProductService.java
+++ b/src/main/java/com/interview/demo/service/ProductService.java
@@ -3,6 +3,7 @@ package com.interview.demo.service;
 import com.interview.demo.dto.ProductDTO;
 import com.interview.demo.dto.PatchProductRequest;
 import com.interview.demo.dto.ProductResponse;
+import com.interview.demo.dto.ProductSummaryResponse;
 import com.interview.demo.entity.Category;
 import com.interview.demo.entity.Product;
 import com.interview.demo.exception.ConflictException;
@@ -13,7 +14,6 @@ import com.interview.demo.repository.projection.ProductSummary;
 import com.interview.demo.repository.specification.ProductSpecifications;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -40,8 +40,8 @@ public class ProductService implements ProductServiceContract {
   }
 
   @Transactional(readOnly = true)
-  public Optional<ProductResponse> getProductById(Long id) {
-    return productRepository.findById(id).map(this::toResponse);
+  public ProductResponse getProductById(Long id) {
+    return toResponse(getById(id));
   }
 
   @Transactional
@@ -82,8 +82,8 @@ public class ProductService implements ProductServiceContract {
     return productRepository.findAll(spec, pageable).map(this::toResponse);
   }
 
-  public List<ProductSummary> getProductSummaries() {
-    return productRepository.findAllProjectedBy();
+  public List<ProductSummaryResponse> getProductSummaries() {
+    return productRepository.findAllProjectedBy().stream().map(this::toSummaryResponse).toList();
   }
 
   @Transactional
@@ -136,6 +136,10 @@ public class ProductService implements ProductServiceContract {
         product.getPrice(),
         categoryId,
         categoryName);
+  }
+
+  private ProductSummaryResponse toSummaryResponse(ProductSummary summary) {
+    return new ProductSummaryResponse(summary.getName(), summary.getPrice());
   }
 
   public Product getById(Long productId) {

--- a/src/main/java/com/interview/demo/service/ProductServiceContract.java
+++ b/src/main/java/com/interview/demo/service/ProductServiceContract.java
@@ -3,17 +3,17 @@ package com.interview.demo.service;
 import com.interview.demo.dto.PatchProductRequest;
 import com.interview.demo.dto.ProductDTO;
 import com.interview.demo.dto.ProductResponse;
+import com.interview.demo.dto.ProductSummaryResponse;
 import com.interview.demo.entity.Product;
 import com.interview.demo.repository.projection.ProductSummary;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 
 public interface ProductServiceContract {
   List<ProductResponse> getAllProducts();
 
-  Optional<ProductResponse> getProductById(Long id);
+  ProductResponse getProductById(Long id);
 
   ProductResponse saveProduct(ProductDTO product);
 
@@ -22,7 +22,7 @@ public interface ProductServiceContract {
   Page<ProductResponse> searchProducts(
       String name, BigDecimal minPrice, BigDecimal maxPrice, int page, int size);
 
-  List<ProductSummary> getProductSummaries();
+  List<ProductSummaryResponse> getProductSummaries();
 
   ProductResponse updateProduct(Long id, ProductDTO product);
 

--- a/src/test/java/com/interview/demo/InventoryApiIT.java
+++ b/src/test/java/com/interview/demo/InventoryApiIT.java
@@ -61,7 +61,10 @@ class InventoryApiIT extends PostgresContainerTestBase {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").exists())
         .andExpect(jsonPath("$.name").value("Electronics"))
-        .andExpect(jsonPath("$.products").doesNotExist());
+        .andExpect(jsonPath("$.products").doesNotExist())
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._links.categories.href").exists())
+        .andExpect(jsonPath("$._links.products.href").exists());
 
     mockMvc
         .perform(
@@ -80,10 +83,12 @@ class InventoryApiIT extends PostgresContainerTestBase {
     mockMvc
         .perform(get("/categories"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(2))
-        .andExpect(jsonPath("$[0].id").exists())
-        .andExpect(jsonPath("$[0].name").exists())
-        .andExpect(jsonPath("$[0].products").doesNotExist());
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._embedded.categoryResponseList.length()").value(2))
+        .andExpect(jsonPath("$._embedded.categoryResponseList[0].id").exists())
+        .andExpect(jsonPath("$._embedded.categoryResponseList[0].name").exists())
+        .andExpect(jsonPath("$._embedded.categoryResponseList[0].products").doesNotExist())
+        .andExpect(jsonPath("$._embedded.categoryResponseList[0]._links.self.href").exists());
   }
 
   @Test
@@ -101,17 +106,18 @@ class InventoryApiIT extends PostgresContainerTestBase {
     mockMvc
         .perform(get("/categories/details"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(2))
-        .andExpect(jsonPath("$[0].id").value(electronics.getId()))
-        .andExpect(jsonPath("$[0].name").value("Electronics"))
-        .andExpect(jsonPath("$[0].products.length()").value(2))
-        .andExpect(jsonPath("$[0].products[0].name").value("Alpha Keyboard"))
-        .andExpect(jsonPath("$[0].products[0].price").value(99.99))
-        .andExpect(jsonPath("$[0].products[0].description").doesNotExist())
-        .andExpect(jsonPath("$[0].products[1].name").value("Zeta Mouse"))
-        .andExpect(jsonPath("$[1].id").value(books.getId()))
-        .andExpect(jsonPath("$[1].name").value("Books"))
-        .andExpect(jsonPath("$[1].products.length()").value(0));
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList.length()").value(2))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].id").value(electronics.getId()))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].name").value("Electronics"))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].products.length()").value(2))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].products[0].name").value("Alpha Keyboard"))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].products[0].price").value(99.99))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].products[0].description").doesNotExist())
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].products[1].name").value("Zeta Mouse"))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[1].id").value(books.getId()))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[1].name").value("Books"))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[1].products.length()").value(0));
   }
 
   @Test
@@ -123,10 +129,11 @@ class InventoryApiIT extends PostgresContainerTestBase {
     mockMvc
         .perform(get("/categories/details").param("page", "2").param("size", "2"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(1))
-        .andExpect(jsonPath("$[0].id").value(office.getId()))
-        .andExpect(jsonPath("$[0].name").value("Office"))
-        .andExpect(jsonPath("$[0].products.length()").value(0));
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList.length()").value(1))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].id").value(office.getId()))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].name").value("Office"))
+        .andExpect(jsonPath("$._embedded.categoryResponseDetailsList[0].products.length()").value(0));
   }
 
   @Test
@@ -161,12 +168,16 @@ class InventoryApiIT extends PostgresContainerTestBase {
                             new BigDecimal("1999.99"),
                             category.getId()))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.name").value("Laptop Pro"));
+        .andExpect(jsonPath("$.name").value("Laptop Pro"))
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._links.category.href").exists());
 
     mockMvc
         .perform(get("/products/by-category/Electronics"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].name").value("Laptop Pro"));
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._embedded.productResponseList[0].name").value("Laptop Pro"))
+        .andExpect(jsonPath("$._embedded.productResponseList[0]._links.self.href").exists());
   }
 
   @Test
@@ -182,11 +193,13 @@ class InventoryApiIT extends PostgresContainerTestBase {
                 .param("minPrice", "1000")
                 .param("maxPrice", "1700"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content.length()").value(1))
-        .andExpect(jsonPath("$.content[0].name").value("Gaming Laptop"))
-        .andExpect(jsonPath("$.number").value(0))
-        .andExpect(jsonPath("$.size").value(20))
-        .andExpect(jsonPath("$.totalElements").value(1));
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._embedded.productResponseList.length()").value(1))
+        .andExpect(jsonPath("$._embedded.productResponseList[0].name").value("Gaming Laptop"))
+        .andExpect(jsonPath("$.page.number").value(0))
+        .andExpect(jsonPath("$.page.size").value(20))
+        .andExpect(jsonPath("$.page.totalElements").value(1))
+        .andExpect(jsonPath("$._embedded.productResponseList[0]._links.self.href").exists());
   }
 
   @Test
@@ -198,11 +211,11 @@ class InventoryApiIT extends PostgresContainerTestBase {
     mockMvc
         .perform(get("/products/search").param("name", "laptop"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content.length()").value(20))
-        .andExpect(jsonPath("$.number").value(0))
-        .andExpect(jsonPath("$.size").value(20))
-        .andExpect(jsonPath("$.totalElements").value(25))
-        .andExpect(jsonPath("$.totalPages").value(2));
+        .andExpect(jsonPath("$._embedded.productResponseList.length()").value(20))
+        .andExpect(jsonPath("$.page.number").value(0))
+        .andExpect(jsonPath("$.page.size").value(20))
+        .andExpect(jsonPath("$.page.totalElements").value(25))
+        .andExpect(jsonPath("$.page.totalPages").value(2));
   }
 
   @Test
@@ -214,12 +227,12 @@ class InventoryApiIT extends PostgresContainerTestBase {
     mockMvc
         .perform(get("/products/search").param("name", "laptop").param("page", "2").param("size", "2"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content.length()").value(1))
-        .andExpect(jsonPath("$.content[0].name").value("Laptop 3"))
-        .andExpect(jsonPath("$.number").value(1))
-        .andExpect(jsonPath("$.size").value(2))
-        .andExpect(jsonPath("$.totalElements").value(3))
-        .andExpect(jsonPath("$.totalPages").value(2));
+        .andExpect(jsonPath("$._embedded.productResponseList.length()").value(1))
+        .andExpect(jsonPath("$._embedded.productResponseList[0].name").value("Laptop 3"))
+        .andExpect(jsonPath("$.page.number").value(1))
+        .andExpect(jsonPath("$.page.size").value(2))
+        .andExpect(jsonPath("$.page.totalElements").value(3))
+        .andExpect(jsonPath("$.page.totalPages").value(2));
   }
 
   @Test
@@ -245,9 +258,10 @@ class InventoryApiIT extends PostgresContainerTestBase {
     mockMvc
         .perform(get("/products/summaries"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].name").value("Monitor"))
-        .andExpect(jsonPath("$[0].price").value(299.99))
-        .andExpect(jsonPath("$[0].description").doesNotExist());
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._embedded.productSummaryResponseList[0].name").value("Monitor"))
+        .andExpect(jsonPath("$._embedded.productSummaryResponseList[0].price").value(299.99))
+        .andExpect(jsonPath("$._embedded.productSummaryResponseList[0].description").doesNotExist());
   }
 
   @Test
@@ -273,7 +287,12 @@ class InventoryApiIT extends PostgresContainerTestBase {
             jsonPath("$.createdAt")
                 .value(org.hamcrest.Matchers.matchesRegex("\\d{4}-\\d{2}-\\d{2}")))
         .andExpect(jsonPath("$.items.length()").value(2))
-        .andExpect(jsonPath("$.items[0].order").doesNotExist());
+        .andExpect(jsonPath("$.items[0].order").doesNotExist())
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._links.orders.href").exists())
+        .andExpect(jsonPath("$._links.items.href").exists())
+        .andExpect(jsonPath("$._links.confirm.href").exists())
+        .andExpect(jsonPath("$._links.cancel.href").exists());
   }
 
   @Test
@@ -302,13 +321,16 @@ class InventoryApiIT extends PostgresContainerTestBase {
     mockMvc
         .perform(get("/orders/{id}/items", orderId))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(2))
-        .andExpect(jsonPath("$[0].id").exists())
-        .andExpect(jsonPath("$[0].productId").exists())
-        .andExpect(jsonPath("$[0].productName").exists())
-        .andExpect(jsonPath("$[0].quantity").exists())
-        .andExpect(jsonPath("$[0].unitPrice").exists())
-        .andExpect(jsonPath("$[0].lineTotal").exists());
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._embedded.orderItemResponseList.length()").value(2))
+        .andExpect(jsonPath("$._embedded.orderItemResponseList[0].id").exists())
+        .andExpect(jsonPath("$._embedded.orderItemResponseList[0].productId").exists())
+        .andExpect(jsonPath("$._embedded.orderItemResponseList[0].productName").exists())
+        .andExpect(jsonPath("$._embedded.orderItemResponseList[0].quantity").exists())
+        .andExpect(jsonPath("$._embedded.orderItemResponseList[0].unitPrice").exists())
+        .andExpect(jsonPath("$._embedded.orderItemResponseList[0].lineTotal").exists())
+        .andExpect(jsonPath("$._embedded.orderItemResponseList[0]._links.product.href").exists())
+        .andExpect(jsonPath("$._embedded.orderItemResponseList[0]._links.order.href").exists());
   }
 
   @Test
@@ -388,7 +410,8 @@ class InventoryApiIT extends PostgresContainerTestBase {
                 .content(json(new CreateCategoryRequest("Audio"))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(category.getId()))
-        .andExpect(jsonPath("$.name").value("Audio"));
+        .andExpect(jsonPath("$.name").value("Audio"))
+        .andExpect(jsonPath("$._links.self.href").exists());
   }
 
   @Test
@@ -403,7 +426,8 @@ class InventoryApiIT extends PostgresContainerTestBase {
     mockMvc
         .perform(get("/categories"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(0));
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._embedded").doesNotExist());
   }
 
   @Test
@@ -446,7 +470,9 @@ class InventoryApiIT extends PostgresContainerTestBase {
         .andExpect(jsonPath("$.name").value("Gaming Mouse"))
         .andExpect(jsonPath("$.price").value(49.99))
         .andExpect(jsonPath("$.categoryId").value(newCategory.getId()))
-        .andExpect(jsonPath("$.categoryName").value("Accessories"));
+        .andExpect(jsonPath("$.categoryName").value("Accessories"))
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._links.category.href").exists());
   }
 
   @Test
@@ -464,7 +490,8 @@ class InventoryApiIT extends PostgresContainerTestBase {
         .andExpect(jsonPath("$.id").value(product.getId()))
         .andExpect(jsonPath("$.name").value("Gaming Mouse"))
         .andExpect(jsonPath("$.description").value("Mouse description"))
-        .andExpect(jsonPath("$.price").value(20.00));
+        .andExpect(jsonPath("$.price").value(20.00))
+        .andExpect(jsonPath("$._links.self.href").exists());
   }
 
   @Test
@@ -486,7 +513,9 @@ class InventoryApiIT extends PostgresContainerTestBase {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(product.getId()))
         .andExpect(jsonPath("$.categoryId").value(newCategory.getId()))
-        .andExpect(jsonPath("$.categoryName").value("Accessories"));
+        .andExpect(jsonPath("$.categoryName").value("Accessories"))
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._links.category.href").exists());
   }
 
   @Test
@@ -598,7 +627,10 @@ class InventoryApiIT extends PostgresContainerTestBase {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(orderId))
         .andExpect(jsonPath("$.status").value("CONFIRMED"))
-        .andExpect(jsonPath("$.totalAmount").value(200.00));
+        .andExpect(jsonPath("$.totalAmount").value(200.00))
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._links.confirm").doesNotExist())
+        .andExpect(jsonPath("$._links.cancel").doesNotExist());
   }
 
   @Test

--- a/src/test/java/com/interview/demo/ProductControllerTest.java
+++ b/src/test/java/com/interview/demo/ProductControllerTest.java
@@ -43,11 +43,16 @@ class ProductControllerTest extends PostgresContainerTestBase {
         .andExpect(jsonPath("$.id").exists())
         .andExpect(jsonPath("$.name").value("Test Product"))
         .andExpect(jsonPath("$.description").value("This is a test product"))
-        .andExpect(jsonPath("$.price").value(9.99));
+        .andExpect(jsonPath("$.price").value(9.99))
+        .andExpect(jsonPath("$._links.self.href").exists())
+        .andExpect(jsonPath("$._links.products.href").exists());
   }
 
   @Test
   void shouldGetAllProducts() throws Exception {
-    mockMvc.perform(get("/products")).andExpect(status().isOk());
+    mockMvc
+        .perform(get("/products"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$._links.self.href").exists());
   }
 }


### PR DESCRIPTION
Implemented Spring HATEOAS across the category, product, and order APIs. pom.xml now includes spring-boot-starter-hateoas, the controllers return EntityModel /
  CollectionModel / PagedModel, and I added three assemblers under src/main/java/com/interview/demo/hateoas to generate controller-driven links with WebMvcLinkBuilder.

  The API now has canonical read endpoints for GET /categories/{id}, GET /products/{id}, GET /orders, and GET /orders/{id}. Existing read routes now emit HAL-style
  _links, collection endpoints expose embedded item resources, product resources link back to their category, category resources link to their associated products
  collection, and order resources include conditional confirm / cancel links when status is CREATED. I also extended the service contracts only at the read layer;
  repository interfaces and persistence logic were left unchanged.

  Tests in src/test/java/com/interview/demo/InventoryApiIT.java and src/test/java/com/interview/demo/ProductControllerTest.java were updated for the HAL response
  format.

  • The summaries endpoint now returns concrete ProductSummaryResponse records instead of raw projection proxies, which makes the HAL embedded rel stable. I added src/
  main/java/com/interview/demo/dto/ProductSummaryResponse.java, updated the product service/controller to return List<ProductSummaryResponse> /
  CollectionModel<ProductSummaryResponse>, and changed the failing test in src/test/java/com/interview/demo/InventoryApiIT.java:257 to assert
  "$._embedded.productSummaryResponseList[0]...".
  
Updated README.md to document the HATEOAS rollout and the current API surface. It now includes Spring HATEOAS in the stack, a HAL response overview, the new
  canonical read endpoints for categories/products/orders, the paged search response shape, the stable /products/summaries embedded rel, and an example order response
  showing conditional confirm / cancel links.

  I also did a readback check to make sure the documented relation names match the current assemblers: categoryResponseList, productResponseList,
  productSummaryResponseList, and the order links self, orders, items, confirm, cancel.
closes #8 