### PR TITLE
update httpreq files to include HATEOAS

### DIFF
--- a/src/httpreq/Category.http
+++ b/src/httpreq/Category.http
@@ -1,6 +1,10 @@
+### HAL collection response with `_embedded` and collection/item `_links`
 GET http://localhost:8080/categories
 ###
-GET http://localhost:8080/categories/details
+GET http://localhost:8080/categories/1
+
+###
+GET http://localhost:8080/categories/details?page=1&size=20
 
 ###
 POST http://localhost:8080/categories

--- a/src/httpreq/Order.http
+++ b/src/httpreq/Order.http
@@ -1,3 +1,10 @@
+### HAL collection response with `_embedded`; CREATED orders include `confirm` and `cancel` links
+GET http://localhost:8080/orders
+
+###
+GET http://localhost:8080/orders/1
+
+###
 POST http://localhost:8080/orders
 Content-Type: application/json
 
@@ -15,6 +22,14 @@ Content-Type: application/json
 
 {
   "status": "CONFIRMED"
+}
+
+###
+PUT http://localhost:8080/orders/1
+Content-Type: application/json
+
+{
+  "status": "CANCELLED"
 }
 
 ###

--- a/src/httpreq/Products.http
+++ b/src/httpreq/Products.http
@@ -1,4 +1,8 @@
+### HAL collection response with `_embedded`; item responses include `_links`
 GET http://localhost:8080/products
+###
+GET http://localhost:8080/products/1
+
 ###
 POST http://localhost:8080/products
 Content-Type: application/json
@@ -39,4 +43,5 @@ GET http://localhost:8080/products/by-category/Electronics
 GET http://localhost:8080/products/search?name=prod&minPrice=10&maxPrice=100&page=1&size=20
 
 ###
+### HAL summaries are embedded under `_embedded.productSummaryResponseList`
 GET http://localhost:8080/products/summaries


### PR DESCRIPTION
Updated src/httpreq/Category.http, src/httpreq/Products.http, and src/httpreq/Order.http to match the current API.

  The files now include the new canonical read endpoints:

  - GET /categories/{id}
  - GET /products/{id}
  - GET /orders
  - GET /orders/{id}

  I also added lightweight HAL notes where useful, kept the existing create/update/delete/error examples, switched category details to an explicit paged request, and
  added a CANCELLED order status update example alongside CONFIRMED.